### PR TITLE
Update sacct call to Alloctres from deprecated Allocgres.

### DIFF
--- a/gpus.go
+++ b/gpus.go
@@ -38,7 +38,7 @@ func GPUsGetMetrics() *GPUsMetrics {
 func ParseAllocatedGPUs() float64 {
 	var num_gpus = 0.0
 
-	args := []string{"-a", "-X", "--format=Allocgres", "--state=RUNNING", "--noheader", "--parsable2"}
+	args := []string{"-a", "-X", "--format=Alloctres", "--state=RUNNING", "--noheader", "--parsable2"}
 	output := string(Execute("sacct", args))
 	if len(output) > 0 {
 		for _, line := range strings.Split(output, "\n") {


### PR DESCRIPTION
The existing call in 'ParseAllocatedGPUs()' to 'sacct' uses the argument '--format=Allocgres', which causes a fatal error in 'sacct' saying "sacct: fatal: AllocGRES is deprecated, please use AllocTRES". This patch changes the call to 'Alloctres', which works.